### PR TITLE
Fix end_date param validation

### DIFF
--- a/azure/terraform/monitoring/alert/budget/variables.tf
+++ b/azure/terraform/monitoring/alert/budget/variables.tf
@@ -10,7 +10,7 @@ variable "end_date" {
   type        = string
   description = "Staring date of the budget rule, should be first day of the month"
   validation {
-    condition     = can(regex("^(\\d{4}-11-01T\\d{2}:\\d{2}:\\d{2}Z)$", var.start_date))
+    condition     = can(regex("^(\\d{4}-11-01T\\d{2}:\\d{2}:\\d{2}Z)$", var.end_date))
     error_message = "The 'end_date' must be in the format 'YYYY-11-01THH:MM:SSZ', e.g., '2023-11-01T00:00:00Z'."
   }
 }

--- a/azure/terraform/monitoring/alert/budget/variables.tf
+++ b/azure/terraform/monitoring/alert/budget/variables.tf
@@ -8,7 +8,7 @@ variable "budget_name" {
 
 variable "end_date" {
   type        = string
-  description = "Staring date of the budget rule, should be first day of the month"
+  description = "End date of the budget rule, should be first day of the month"
   validation {
     condition     = can(regex("^(\\d{4}-11-01T\\d{2}:\\d{2}:\\d{2}Z)$", var.end_date))
     error_message = "The 'end_date' must be in the format 'YYYY-11-01THH:MM:SSZ', e.g., '2023-11-01T00:00:00Z'."
@@ -17,7 +17,7 @@ variable "end_date" {
 
 variable "start_date" {
   type        = string
-  description = "Staring date of the budget rule, should be first day of the month"
+  description = "Start date of the budget rule, should be first day of the month"
   validation {
     condition     = can(regex("^(\\d{4}-11-01T\\d{2}:\\d{2}:\\d{2}Z)$", var.start_date))
     error_message = "The 'start_date' must be in the format 'YYYY-11-01THH:MM:SSZ', e.g., '2023-11-01T00:00:00Z'."


### PR DESCRIPTION
The condition for variable "end_date" must refer to var.end_date in order to test incoming values.