### PR TITLE
Update curl command to download sg-cli

### DIFF
--- a/other-providers/stackguardian/main.tf
+++ b/other-providers/stackguardian/main.tf
@@ -1,6 +1,7 @@
 resource "null_resource" "sg_integration" {
   provisioner "local-exec" {
     command = <<EOF
+
 curl -o sg-cli https://raw.githubusercontent.com/StackGuardian/sg-cli/main/sg-cli
 chmod +x sg-cli
 


### PR DESCRIPTION
SG moved the location of the executable file `sg-cli` in their repo. updated curl command in `main.tf` to reflect new location of executable
